### PR TITLE
Add arbitrary hosts by docker label

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Entries are created for each container network with the following names:
 
 Each container will thereforr have up to 4 entries per alias: CONTAINER_ALIAS, CONTAINER_ALIAS.PROJECT, CONTAINER_ALIAS.NETWORK_NAME, CONTAINER_ALIAS.PROJECT.NETWORK_NAME
 
-Arbitrary hosts entries can be added via a custom label (`com.costela.docker-etchosts.add_hosts`) by specifying a single or array of host names.
+Arbitrary hosts entries can be added via a custom label (`net.costela.docker-etchosts.extra_hosts`) by specifying a single or array of host names.
 
 This means the following `docker-compose.yml` setup for project `someproject`:
 ```yaml
@@ -47,7 +47,7 @@ services:
   someservice:
     ...
     labels:
-        - 'com.costela.docker-etchosts.add_hosts=["a.example.com", "b.example.com"]'
+        - 'net.costela.docker-etchosts.extra_hosts=["a.example.com", "b.example.com"]'
     networks:
       somenet:
         aliases:

--- a/README.md
+++ b/README.md
@@ -39,11 +39,15 @@ Entries are created for each container network with the following names:
 
 Each container will thereforr have up to 4 entries per alias: CONTAINER_ALIAS, CONTAINER_ALIAS.PROJECT, CONTAINER_ALIAS.NETWORK_NAME, CONTAINER_ALIAS.PROJECT.NETWORK_NAME
 
+Arbitrary hosts entries can be added via a custom label (`com.costela.docker-etchosts.add_hosts`) by specifying a single or array of host names.
+
 This means the following `docker-compose.yml` setup for project `someproject`:
 ```yaml
 services:
   someservice:
     ...
+    labels:
+        - 'com.costela.docker-etchosts.add_hosts=["a.example.com", "b.example.com"]'
     networks:
       somenet:
         aliases:
@@ -51,7 +55,7 @@ services:
 ```
 Would generate the following hosts entry:
 ```
-x.x.x.x     someservice someservice.somenet someservice.someproject someservice.someproject.somenet somealias somealias.somenet somealias.someproject somealias.someproject.somenet
+x.x.x.x     someservice someservice.somenet someservice.someproject someservice.someproject.somenet somealias somealias.somenet somealias.someproject somealias.someproject.somenet a.example.com b.example.com
 ```
 
 _NOTE_: Docker ensures the uniqueness of containers' IP addresses and names, but does not ensure uniqueness for aliases. This may lead to multiple entries having the same name, especially for the shorter name versions. The longer, more explict, names are there to help in these cases, enabling different workflows with multiple projects.

--- a/docker.go
+++ b/docker.go
@@ -25,6 +25,8 @@ type dockerClientPinger interface {
 	Ping(context.Context) (types.Ping, error)
 }
 
+const dockerLabel string = "net.costela.docker-etchosts.extra_hosts";
+
 func getAllIPsToNames(client dockerClienter) (ipsToNamesMap, error) {
 	containers, err := client.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err != nil {
@@ -90,7 +92,7 @@ func getIPsToNames(client dockerClienter, id string) (ipsToNamesMap, error) {
 			names = appendNames(names, name)
 		}
 
-		if label, ok := containerFull.Config.Labels["com.costela.docker-etchosts.add_hosts"]; ok {
+		if label, ok := containerFull.Config.Labels[dockerLabel]; ok {
 			if (strings.HasPrefix(label, "[")) {
 				var parsed []string; 
 				err := json.Unmarshal([]byte(label), &parsed)

--- a/docker_test.go
+++ b/docker_test.go
@@ -128,7 +128,7 @@ func (testClient) ContainerInspect(_ context.Context, ID string) (types.Containe
 		return types.ContainerJSON{
 			ContainerJSONBase: &types.ContainerJSONBase{Name: "service5"},
 			Config:            &container.Config{Labels: map[string]string{
-				dockerLabel: `["a.example.com", "b.example.com"]`,
+				dockerLabel: `["a.example.com", "b.example.com", "invalid."]`,
 			}},
 			NetworkSettings: &types.NetworkSettings{
 				Networks: map[string]*network.EndpointSettings{

--- a/docker_test.go
+++ b/docker_test.go
@@ -128,7 +128,7 @@ func (testClient) ContainerInspect(_ context.Context, ID string) (types.Containe
 		return types.ContainerJSON{
 			ContainerJSONBase: &types.ContainerJSONBase{Name: "service5"},
 			Config:            &container.Config{Labels: map[string]string{
-				"com.costela.docker-etchosts.add_hosts": "[\"a.example.com\", \"b.example.com\"]",
+				dockerLabel: `["a.example.com", "b.example.com"]`,
 			}},
 			NetworkSettings: &types.NetworkSettings{
 				Networks: map[string]*network.EndpointSettings{


### PR DESCRIPTION
Hello!

First of all thank you for this great tool!
We need to attach arbitrary host names to some containers e.g. for using google oauth. This adds the ability to provide it via a docker label called: `com.costela.docker-etchosts.host`

This is my first go code ever.

I thinking about adding support for json arrays like something this:  

```go
package main

import (
	"encoding/json"
	"fmt"
)

func main() {
	hostsJson := `["s"]`
	var hosts []string
	err := json.Unmarshal([]byte(hostsJson), &hosts)
	if err != nil {
		fmt.Println(err)
	}
	for _, host := range hosts {
		fmt.Printf("%s", host)
	}
}
```

TODO:

- [x] json array?
- [x] tests?
- [x] readme update



